### PR TITLE
Fix Data.Vector.Unboxed.Mutable.grow

### DIFF
--- a/bitvec.cabal
+++ b/bitvec.cabal
@@ -54,7 +54,7 @@ Test-Suite bitvec-tests
                         test-framework,
                         test-framework-hunit,
                         test-framework-quickcheck2,
-                        QuickCheck
+                        QuickCheck >= 2.10
 
 Library
   hs-source-dirs:       src

--- a/src/Data/Vector/Unboxed/Bit/Internal.hs
+++ b/src/Data/Vector/Unboxed/Bit/Internal.hs
@@ -110,7 +110,11 @@ instance U.Unbox Bit
 
 instance MV.MVector U.MVector Bit where
 #if MIN_VERSION_vector(0,11,0)
-    basicInitialize (BitMVec _ _ v) = MV.basicInitialize v
+    basicInitialize (BitMVec 0 _ v) = MV.basicInitialize v
+    basicInitialize (BitMVec s _ v) = do
+        x <- MV.basicUnsafeRead v 0
+        MV.basicInitialize v
+        MV.basicUnsafeWrite v 0 (x .&. (1 `shiftL` s - 1))
 #endif
     
     basicUnsafeNew       n   = liftM (BitMVec 0 n) (MV.basicUnsafeNew       (nWords n))

--- a/test/Support.hs
+++ b/test/Support.hs
@@ -26,9 +26,6 @@ instance CoArbitrary Bit where
 instance Function Bit where
     function f = functionMap toBool fromBool f
 
-instance Function Word where
-    function f = functionMap (fromIntegral :: Word -> Int) fromIntegral f
-
 instance (Arbitrary a, U.Unbox a) => Arbitrary (U.Vector a) where
     arbitrary = V.new <$> arbitrary
 


### PR DESCRIPTION
Fixes #4. Quite surprisingly the issue was caused by too aggressive `basicInitialize`.